### PR TITLE
fix(nav): show offcanvas menu items and remove duplicate close X

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -1016,19 +1016,22 @@ img.octagon {
     font-size: 15px;
     font-weight: 700;
     letter-spacing: -0.5px;
-    color: #404040;
+    color: #404040 !important;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
     transition: all 0.2s ease-in-out;
 }
 .offcanvas-body .nav-link:hover,
 .offcanvas-body .nav-link.active {
-    color: #4c86e5;
+    color: #4c86e5 !important;
     background-color: rgba(76, 134, 229, 0.05);
 }
 .offcanvas .btn-close {
     width: 1em;
     height: 1em;
     padding: 0.5rem;
+}
+.hamburger.animate.active {
+    visibility: hidden;
 }
 /*-----------------------------------------------------------------------------------*/
 /*	07. BUTTON


### PR DESCRIPTION
## Summary

Fixes two issues with the mobile hamburger menu:

- **Invisible nav items**: The mobile media query at `style.css:5830` forces `.navbar-nav .nav-link { color: rgba(255,255,255,1) !important }`. Because the offcanvas drawer's `<ul>` carries the `navbar-nav` class, the menu items rendered as white text on the white panel. Added `!important` to `.offcanvas-body .nav-link` color so they stay visible.
- **Two overlapping X icons**: The navbar hamburger animates into an X (via `.hamburger.animate.active`) while the offcanvas-header also shows a `.btn-close`, so two close icons appeared at once. Added `.hamburger.animate.active { visibility: hidden }` to hide the hamburger while the panel is open. The existing `hide.bs.offcanvas` handler in `custom-scripts.js` clears `.active`, so the hamburger reappears when the panel closes.

## Test plan

- [ ] On a mobile viewport (<992px), open the hamburger menu and confirm Home / About / Portfolio / Services / Schedule / Contact are visible
- [ ] Confirm only one X close button is visible while the panel is open
- [ ] Tap the panel's X (or the backdrop) and confirm the hamburger reappears in the navbar
- [ ] Tap a nav link and confirm the panel closes and the page scrolls to the section
- [ ] Verify the desktop nav (≥992px) still renders normally

https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN)_