### PR TITLE
build(vite): cache-bust custom scripts via content-hashed ?v= query

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,32 @@
 import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { resolve } from 'path'
+import { createHash } from 'crypto'
+import { readFileSync } from 'fs'
+
+const HASHED_SCRIPTS = [
+  'style/js/custom-plugins.js',
+  'style/js/custom-scripts.js',
+]
+
+function cacheBustStaticScripts() {
+  return {
+    name: 'cache-bust-static-scripts',
+    transformIndexHtml: {
+      order: 'post',
+      handler(html) {
+        for (const src of HASHED_SCRIPTS) {
+          const content = readFileSync(resolve(__dirname, src))
+          const hash = createHash('md5').update(content).digest('hex').slice(0, 8)
+          const escaped = src.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+          const pattern = new RegExp(`(<script[^>]*\\bsrc=")(${escaped})(")`)
+          html = html.replace(pattern, `$1$2?v=${hash}$3`)
+        }
+        return html
+      },
+    },
+  }
+}
 
 export default defineConfig({
   root: '.',
@@ -34,6 +60,7 @@ export default defineConfig({
   },
 
   plugins: [
+    cacheBustStaticScripts(),
     viteStaticCopy({
       targets: [
         // Copy vendor JS files that should not be bundled


### PR DESCRIPTION
## Summary

`style/js/custom-plugins.js` and `style/js/custom-scripts.js` are static-copied to `/style/js/` without a content hash, and the deploy step tags everything outside `index.html` with `cache-control: public, max-age=31536000, immutable`. That means once a browser loads either file, edits to them are **never picked up** for up to a year, regardless of CloudFront invalidation.

This adds a small Vite plugin (`cacheBustStaticScripts`) that, during `transformIndexHtml`, computes an md5 of each file's contents and appends `?v=<hash>` to its `<script src>` in `dist/index.html`. The query string changes whenever the file content changes, so the browser treats it as a new URL and refetches.

After build:
```html
<script src="style/js/custom-plugins.js?v=6abc4026"></script>
<script src="style/js/custom-scripts.js?v=abadc00c"></script>
```

Vendor libs (`bootstrap.bundle.min.js`, `embla-*`, `glightbox.min.js`, `muuri.min.js`) are intentionally left alone — they're version-pinned and rarely change. Vite already bundles+hashes the CSS via `<link>` processing, so no change is needed there.

## Test plan

- [ ] `npm run build` succeeds
- [ ] `dist/index.html` shows `?v=<hash>` on both custom JS scripts
- [ ] Edit `custom-scripts.js`, rebuild, confirm the hash on that script changes
- [ ] Live: after merge, confirm Network tab shows the updated `?v=` and re-fetches the JS

https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN)_