### PR TITLE
fix(nav): scope mobile white-text rule so it stops leaking into offcanvas

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -1016,13 +1016,13 @@ img.octagon {
     font-size: 15px;
     font-weight: 700;
     letter-spacing: -0.5px;
-    color: #404040 !important;
+    color: #404040;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
     transition: all 0.2s ease-in-out;
 }
 .offcanvas-body .nav-link:hover,
 .offcanvas-body .nav-link.active {
-    color: #4c86e5 !important;
+    color: #4c86e5;
     background-color: rgba(76, 134, 229, 0.05);
 }
 .offcanvas .btn-close {
@@ -5830,7 +5830,7 @@ list-blue i {
         padding-top: 19px;
         padding-bottom: 18px;
     }
-    .navbar-nav .nav-link {
+    .navbar-collapse .navbar-nav .nav-link {
         font-size: 14px;
         padding-left: 30px;
         padding-right: 30px;
@@ -5866,9 +5866,9 @@ list-blue i {
     .navbar .social-mute a:hover i {
         color: rgba(255, 255, 255, 0.75) !important;
     }
-    .navbar-nav .nav-link:hover,
-    .navbar-nav .nav-link.highlighted,
-    .navbar-nav .nav-link.active {
+    .navbar-collapse .navbar-nav .nav-link:hover,
+    .navbar-collapse .navbar-nav .nav-link.highlighted,
+    .navbar-collapse .navbar-nav .nav-link.active {
         color: rgba(255, 255, 255, 0.75) !important;
     }
     .navbar .navbar-header {


### PR DESCRIPTION
## Summary

Root-causes the offcanvas "invisible nav items" bug at the source instead of patching with `!important` in the offcanvas styles.

The mobile media query at `style.css:5833` was originally written for the inline-collapsed navbar (which used a dark `#151515` background, see line 5818):

```css
@media (max-width: 991.98px) {
    .navbar-nav .nav-link {
        ...
        color: rgba(255, 255, 255, 1) !important;
    }
}
```

But the current markup hides `.navbar-collapse` below `lg` (`d-none d-lg-block`) and uses an offcanvas drawer for mobile. The drawer's `<ul>` carries the `navbar-nav` class, so this white-text `!important` was leaking into the drawer and making the links invisible against the white panel — exactly the bug PR #60 worked around.

This change:

- Scopes the rule (and its hover/active companion) to `.navbar-collapse .navbar-nav .nav-link`, so it only ever affects the inline collapsed menu it was written for.
- Removes the `!important` workaround added to `.offcanvas-body .nav-link` in PR #60, since it's no longer necessary.

The hamburger / duplicate-X fix from PR #60 is unaffected.

## Test plan

- [ ] On mobile viewport (<992px), hamburger menu items show the dark drawer color (#404040)
- [ ] On hover/tap, link color is the brand blue (#4c86e5)
- [ ] Desktop nav (≥992px) is unchanged
- [ ] If the inline-collapse navbar is ever re-enabled (`d-none` removed), its links are still white as before

https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN)_