### PR TITLE
fix(contact): clean up duplicate nav link, empty footer, missing labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,12 +317,11 @@
           <li class="nav-item"><a class="nav-link scroll" href="#about">About</a></li>
           <li class="nav-item"><a class="nav-link scroll" href="#portfolio">Portfolio</a></li>
           <li class="nav-item"><a class="nav-link scroll" href="#services">Services</a></li>
-          <li class="nav-item"><a class="nav-link scroll" href="#contact">Schedule</a></li>
           <li class="nav-item"><a class="nav-link scroll" href="#contact">Contact</a></li>
         </ul>
         <!-- /.navbar-nav -->
       </div>
-      <!-- /.navbar-collapse --> 
+      <!-- /.navbar-collapse -->
     </div>
     <!-- /.container --> 
   </nav>
@@ -339,7 +338,6 @@
         <li class="nav-item"><a class="nav-link scroll" href="#about">About</a></li>
         <li class="nav-item"><a class="nav-link scroll" href="#portfolio">Portfolio</a></li>
         <li class="nav-item"><a class="nav-link scroll" href="#services">Services</a></li>
-        <li class="nav-item"><a class="nav-link scroll" href="#contact">Schedule</a></li>
         <li class="nav-item"><a class="nav-link scroll" href="#contact">Contact</a></li>
       </ul>
     </div>
@@ -1805,33 +1803,36 @@
             <!--/.row -->
             <div class="space30"></div>
             <div class="form-container">
-              <form id="contact-form" action="post">
+              <form id="contact-form">
                 <div class="row text-center">
-                  <div class="col-md-6 pr-10">
+                  <div class="col-md-6">
                     <div class="form-group">
+                      <label for="name" class="visually-hidden">Your name</label>
                       <input type="text" class="form-control" name="name" id="name" placeholder="Your name" required="required" minlength="2">
                     </div>
-                    <!--/.form-group --> 
+                    <!--/.form-group -->
                   </div>
                   <!--/column -->
-                  <div class="col-md-6 pl-10">
+                  <div class="col-md-6">
                     <div class="form-group">
+                      <label for="mail" class="visually-hidden">Your e-mail</label>
                       <input type="email" class="form-control" name="mail" id="mail" placeholder="Your e-mail" required="required">
                     </div>
-                    <!--/.form-group --> 
+                    <!--/.form-group -->
                   </div>
                   <!--/column -->
                   <div class="col-12">
                     <div class="form-group">
+                      <label for="subject" class="visually-hidden">Subject</label>
                       <input type="text" class="form-control" name="subject" id="subject" placeholder="Subject">
                     </div>
-                    <!--/.form-group --> 
+                    <!--/.form-group -->
                   </div>
                   <!--/column -->
                   <div class="col-12">
+                    <label for="comment" class="visually-hidden">Your message</label>
                     <textarea name="comment" id="comment" class="form-control" rows="3" placeholder="Type your message here..." required></textarea>
-                    <button style="background:#9A7A7D; margin-top:20px;" type="button" ID="submitmessage" class="btn btn-full-rounded" onClick="submitToAPI(event)">Send Message</button>
-                    <footer class="notification-box"></footer>
+                    <button style="background:#9A7A7D; margin-top:20px;" type="button" id="submitmessage" class="btn btn-full-rounded" onclick="submitToAPI(event)">Send Message</button>
                     <p id="message" style="margin-top:10px;"></p>
                   </div>
                   <!--/column --> 


### PR DESCRIPTION
## Summary

Addresses six audit findings on `index.html`:

1. **Duplicate "Schedule" / "Contact" nav links** (lines 320-321 + 342-343) — both pointed to `#contact`. Dropped "Schedule" from desktop + offcanvas nav. (The Appointy booking destination it was meant for is the commented-out `<a>` at line 1789; not restored as part of this PR.)
2. **Empty `<footer class="notification-box">`** below the submit button — the fetch-based `submitToAPI` handler writes status to `#message` and never toggles `.show-error` / `.show-success`, so the styled empty box rendered as visible padding under the button.
3. **No form labels** — added `<label class="visually-hidden">` for name / mail / subject / comment so screen readers and autofill announce them properly.
4. **`pl-10` / `pr-10` dead BS4-era utility classes** removed from the Name/Email columns. They didn't exist in any loaded CSS. Row's default gutter remains.
5. **`<form action="post">`** removed — `"post"` is not a valid URL; if JS ever failed to intercept, the form would have navigated to `/post`.
6. **Mixed-case `ID=` and `onClick=`** on the submit button — lowercased for hygiene.

## Test plan

- [ ] Mobile + desktop nav show 5 items (no duplicate Contact / no Schedule)
- [ ] No empty bordered box appears below "Send Message"
- [ ] Screen reader announces "Your name", "Your e-mail", "Subject", "Your message" for each field
- [ ] Form submit still works (sends via the existing Lambda URL + reCAPTCHA flow)
- [ ] Failure to fill required field still shows native validation prompt

https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN)_