### PR TITLE
chore(css): scope mega-menu rule, modernize ml-auto, drop BS4 .close

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -462,18 +462,6 @@ hr.double {
 .divider-icon:after {
     right: 0;
 }
-.close {
-    text-shadow: none;
-}
-.alert button {
-    -webkit-transition: all 150ms ease-in-out;
-    -o-transition: all 150ms ease-in-out;
-    transition: all 150ms ease-in-out;
-    cursor: pointer
-}
-.alert-dismissible .close {
-    padding: 11px 18px 10px;
-}
 .badge {
     text-transform: uppercase;
     font-size: 11px;
@@ -911,8 +899,8 @@ img.octagon {
 /*-----------------------------------------------------------------------------------*/
 /*	05. MEGA MENU
 /*-----------------------------------------------------------------------------------*/
-.navbar-nav,
-.navbar-nav>li.mega-menu {
+.navbar .navbar-nav,
+.navbar .navbar-nav>li.mega-menu {
     position: static !important;
 }
 .navbar-nav>li>ul.mega-menu {
@@ -5749,7 +5737,7 @@ list-blue i {
     .navbar-nav>li>.dropdown-menu {
         border-top: 2px solid #4c86e5;
     }
-    .navbar.center .ml-auto {
+    .navbar.center .ms-auto {
         float: right;
     }
     .navbar.center .navbar-brand {
@@ -5890,7 +5878,7 @@ list-blue i {
         margin: 0;
         border-top: 1px solid rgba(255, 255, 255, 0.08);
     }
-    .navbar:not(.center) .navbar-nav:not(.ml-auto)>li:first-child {
+    .navbar:not(.center) .navbar-nav:not(.ms-auto)>li:first-child {
         border: 0;
     }
     .navbar .navbar-nav.sm-collapsible>li:first-child {


### PR DESCRIPTION
## Summary

Three small CSS hygiene fixes from the audit, no visual change:

1. **`.navbar-nav { position: static !important }`** at `style.css:914` had no `.navbar` ancestor, so it was silently applying to the offcanvas drawer's `<ul class="navbar-nav flex-column">` too. Same shape as the leak fixed in #62. Scoped to `.navbar .navbar-nav`.

2. **BS4 `.ml-auto` selectors** at `style.css:5752` and `5893`. The HTML moved to BS5 `.ms-auto`, so:
   - `.navbar.center .ml-auto { float: right }` never matched anything.
   - `.navbar:not(.center) .navbar-nav:not(.ml-auto) > li:first-child { border: 0 }`'s `:not(.ml-auto)` was always true, so the rule was applying to *every* mobile-collapsed navbar's first item, including ones authored with `ms-auto`. Renamed to `.ms-auto`.

3. **Dead BS4 `.close` styles** at `style.css:465-476`. All close buttons in the markup are BS5 `.btn-close`, and no `.alert` markup exists. Removed.

## Test plan

- [ ] Build succeeds, validations pass
- [ ] No visual change on desktop nav, offcanvas drawer, or any close button
- [ ] If a future submenu/dropdown is added inside the offcanvas, it's free to use absolute/relative positioning without the mega-menu `position: static` leak

https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3wcgW1m63EKJmCUmYRNpN)_