### PR TITLE
docs(claude): correct stylesheet and JS paths in Key Conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ There is no test framework. The validation scripts above serve as the test suite
 - **Do NOT modify `infrastructure/`** -- CDK stacks are managed separately
 - **Do NOT modify `images/`** -- image processing is handled by the `process-images.yml` workflow
 - **Image optimization**: New photos go through `process-images.yml` which handles resizing, WebP conversion, and HTML snippet generation
-- **Single-page site**: `index.html` is the main entry point. CSS in `css/`, JS in `js/`
+- **Single-page site**: `index.html` is the main entry point. Stylesheets in `style/`, JS in `style/js/` and inline in `index.html`.
 - **Deployment**: Auto-deploys to AWS via GitHub Actions on push to `main`
 
 ## AWS Configuration


### PR DESCRIPTION
## Summary

The Key Conventions bullet in `CLAUDE.md` claimed CSS lives in `css/` and JS in `js/`. Neither directory exists at the repo root -- the actual layout puts stylesheets under `style/` and inline JS in `index.html`. This corrects the path claims so the file matches reality.

## Changes

- `CLAUDE.md` -- single bullet on line 24 updated:
  - **Before:** ``- **Single-page site**: `index.html` is the main entry point. CSS in `css/`, JS in `js/` ``
  - **After:** ``- **Single-page site**: `index.html` is the main entry point. Stylesheets in `style/`, JS in `style/js/` and inline in `index.html`. ``

## Why

Future agents (and humans) reading `CLAUDE.md` were being pointed at directories that do not exist. The actual layout is:

```
style/
  css/
  js/
  type/
  style.css
index.html   # contains inline <script> blocks (contact form, gtag)
```

There is no top-level `css/` or `js/` directory.

## Testing

- `ls -la` at the repo root and inside `style/` confirms the new path claims match reality (see commit message for the discovery flow).
- Pre-commit `validate-staged.js` hook passed.
- No code changes, so no build/validate run required.

## Notes for reviewer

Scope was intentionally kept to this single line per the request. Other sections of `CLAUDE.md` that may also drift over time (e.g., the inline path tables) were left alone for a separate pass.